### PR TITLE
Change the twitter follower request url

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
 					.fail(function(jqXHR, textStatus, errorThrown) {
 						console.log("failed: " + errorThrown);
 					});
-				$.ajax({url:"./get.php", data: {site: "twitter"}, dataType: "json"})
+				$.ajax({url:"http://trehe.com/followers/counts.json", dataType: "json"})
 					.done(function(resp) {
 						$("#wankers").html(comma(resp.petegold_));
 						$("#wakersp").html((resp.petegold_/50000*100).toFixed(2));


### PR DESCRIPTION
Changed the Twitter follower request URL to point to the original data source (I enabled CORS on that URL so it should work) which should take some load off the server.

Not that the number of followers these guys have is particularly relevant anymore...
